### PR TITLE
Support Pensieve

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,13 @@ import json
 
 import src.handle_email_queue as handle_email
 import src.handle_flush_gradescope as handle_flush
+import src.handle_flush_pensieve as handle_flush_pensieve_module
 import src.handle_form_submit as handle_form
+from src.environment import Environment
 from src.errors import KnownError
 from src.slack import SlackManager
 from src.utils import truncate
-from src.environment import Environment
+
 
 def handle_email_queue(request):
     request_json = request.get_json()
@@ -20,7 +22,9 @@ def handle_email_queue(request):
         return {"success": False, "error": str(e)}
     except Exception as e:
         print("Internal Error Occurred: " + str(e) + f" (Request: {request_json})")
-        SlackManager().send_error("Internal error: " + str(e) + f" (Request: {truncate(request_json)})")
+        SlackManager().send_error(
+            "Internal error: " + str(e) + f" (Request: {truncate(request_json)})"
+        )
         raise
     finally:
         Environment.clear()
@@ -38,7 +42,29 @@ def handle_flush_gradescope(request):
         return {"success": False, "error": str(e)}
     except Exception as e:
         print("Internal Error Occurred: " + str(e) + f" (Request: {request_json})")
-        SlackManager().send_error("Internal error: " + str(e) + f" (Request: {truncate(request_json)})")
+        SlackManager().send_error(
+            "Internal error: " + str(e) + f" (Request: {truncate(request_json)})"
+        )
+        raise
+    finally:
+        Environment.clear()
+
+
+def handle_flush_pensieve(request):
+    request_json = request.get_json()
+    print("handle_flush_pensieve called on payload: " + json.dumps(request_json))
+    try:
+        handle_flush_pensieve_module.handle_flush_pensieve(request_json=request_json)
+        return {"success": True}
+    except KnownError as e:
+        print("Known Error Occurred: " + str(e) + f" (Request: {request_json})")
+        SlackManager().send_error(str(e) + f" (Request: {truncate(request_json)})")
+        return {"success": False, "error": str(e)}
+    except Exception as e:
+        print("Internal Error Occurred: " + str(e) + f" (Request: {request_json})")
+        SlackManager().send_error(
+            "Internal error: " + str(e) + f" (Request: {truncate(request_json)})"
+        )
         raise
     finally:
         Environment.clear()
@@ -56,7 +82,9 @@ def handle_form_submit(request):
         return {"success": False, "error": str(e)}
     except Exception as e:
         print("Internal Error Occurred: " + str(e) + f" (Request: {request_json})")
-        SlackManager().send_error("Internal error: " + str(e) + f" (Request: {truncate(request_json)})")
+        SlackManager().send_error(
+            "Internal error: " + str(e) + f" (Request: {truncate(request_json)})"
+        )
         raise
     finally:
         Environment.clear()

--- a/src/assignments.py
+++ b/src/assignments.py
@@ -24,6 +24,7 @@ class Assignment:
         hard_due_date: Optional[datetime],
         partner: bool,
         gradescope: List[str],
+        pensieve: List[str],
     ) -> None:
         self.name = name
         self.id = id
@@ -31,6 +32,7 @@ class Assignment:
         self.hard_due_date = hard_due_date
         self.partner = partner
         self.gradescope = gradescope
+        self.pensieve = pensieve
 
     def is_past_due(self, request_time: str):
         """
@@ -67,6 +69,9 @@ class Assignment:
     def get_gradescope_assignment_urls(self) -> List[str]:
         return self.gradescope
 
+    def get_pensieve_assignment_urls(self) -> List[str]:
+        return self.pensieve
+
 
 class AssignmentList:
     """
@@ -86,6 +91,7 @@ class AssignmentList:
                         hard_due_date=cast_date(row.get("hard_due_date", ""), optional=True),
                         partner=cast_bool(row["partner"]),
                         gradescope=cast_list_str(row.get("gradescope", "")),
+                        pensieve=cast_list_str(row.get("pensieve", "")),
                     )
                 )
 

--- a/src/environment.py
+++ b/src/environment.py
@@ -2,6 +2,7 @@ import os
 from typing import Optional
 
 from dotenv import dotenv_values
+
 from src.sheets import Sheet
 
 PREFIX = "flextensions_"
@@ -19,6 +20,7 @@ DEFAULT_EMAIL_SUBJECT = "[CS 000] Extension Request Update"
 DEFAULT_EMAIL_SIGNATURE = "{} Staff".format(DEFAULT_COURSE_NAME)
 
 DEFAULT_EXTEND_GRADESCOPE_ASSIGNMENTS = "No"
+DEFAULT_EXTEND_PENSIEVE_ASSIGNMENTS = "No"
 
 class Environment:
     @staticmethod
@@ -109,6 +111,18 @@ class Environment:
     @staticmethod
     def get_gradescope_password() -> Optional[str]:
         return Environment._safe_get("GRADESCOPE_PASSWORD")
+
+    @staticmethod
+    def get_extend_pensieve_assignments() -> Optional[str]:
+        return Environment._safe_get("EXTEND_PENSIEVE_ASSIGNMENTS", DEFAULT_EXTEND_PENSIEVE_ASSIGNMENTS)
+
+    @staticmethod
+    def get_pensieve_email() -> Optional[str]:
+        return Environment._safe_get("PENSIEVE_EMAIL")
+
+    @staticmethod
+    def get_pensieve_api_token() -> Optional[str]:
+        return Environment._safe_get("PENSIEVE_API_TOKEN")
 
     @staticmethod
     def get_spreadsheet_url() -> Optional[str]:

--- a/src/handle_email_queue.py
+++ b/src/handle_email_queue.py
@@ -5,9 +5,12 @@ from src.email import Email
 from src.environment import Environment
 from src.errors import ConfigurationError
 from src.gradescope import Gradescope
+from src.pensieve import Pensieve
 from src.record import EMAIL_STATUS_IN_QUEUE, StudentRecord
-from src.sheets import SHEET_ASSIGNMENTS, SHEET_ENVIRONMENT_VARIABLES, SHEET_STUDENT_RECORDS, BaseSpreadsheet
+from src.sheets import (SHEET_ASSIGNMENTS, SHEET_ENVIRONMENT_VARIABLES,
+                        SHEET_STUDENT_RECORDS, BaseSpreadsheet)
 from src.slack import SlackManager
+
 
 def handle_email_queue(request_json):
     if "spreadsheet_url" not in request_json:
@@ -52,6 +55,12 @@ def handle_email_queue(request_json):
             if Gradescope.is_enabled():
                 client = Gradescope()
                 warnings = student.apply_extensions(assignments=assignments, gradescope=client)
+                for warning in warnings:
+                    slack.add_warning(warning)
+
+            if Pensieve.is_enabled():
+                pensieve_client = Pensieve()
+                warnings = student.apply_extensions_pensieve(assignments=assignments, pensieve=pensieve_client)
                 for warning in warnings:
                     slack.add_warning(warning)
 

--- a/src/handle_flush_pensieve.py
+++ b/src/handle_flush_pensieve.py
@@ -1,0 +1,64 @@
+from src.assignments import AssignmentList
+from src.environment import Environment
+from src.errors import ConfigurationError
+from src.pensieve import Pensieve
+from src.record import StudentRecord
+from src.sheets import (SHEET_ASSIGNMENTS, SHEET_ENVIRONMENT_VARIABLES,
+                        SHEET_STUDENT_RECORDS, BaseSpreadsheet)
+from src.slack import SlackManager
+
+
+def handle_flush_pensieve(request_json):
+    if "spreadsheet_url" not in request_json:
+        raise ConfigurationError("handle_flush_pensieve expects spreadsheet_url parameter")
+
+    # Get pointers to sheets.
+    base = BaseSpreadsheet(spreadsheet_url=request_json["spreadsheet_url"])
+    sheet_assignments = base.get_sheet(SHEET_ASSIGNMENTS)
+    sheet_records = base.get_sheet(SHEET_STUDENT_RECORDS)
+    sheet_env_vars = base.get_sheet(SHEET_ENVIRONMENT_VARIABLES)
+
+    # Set up environment variables.
+    Environment.configure_env_vars(sheet_env_vars)
+
+    # Fetch assignments.
+    assignments = AssignmentList(sheet=sheet_assignments)
+
+    # Fetch records.
+    records = sheet_records.get_all_records()
+
+    slack = SlackManager()
+
+    pensieve = Pensieve()
+
+    all_warnings = []
+    successes = []
+    failures = []
+    for i, table_record in enumerate(records):
+        student = StudentRecord(table_index=i, table_record=table_record, sheet=sheet_records)
+        if student.should_flush_pensieve():
+            w = student.apply_extensions_pensieve(assignments=assignments, pensieve=pensieve)
+            if len(w) > 0:
+                failures.append(student.get_email())
+                all_warnings.extend(w)
+            else:
+                successes.append(student.get_email())
+                student.set_flush_pensieve_status_success()
+
+        student.flush()
+
+    for warning in all_warnings:
+        slack.add_warning(warning)
+
+    summary = "Flush Pensieve Summary:" + "\n"
+    if len(successes) > 0:
+        summary += "\n" + "*Successes:* " + ", ".join(successes)
+    if len(failures) > 0:
+        summary += "\n" + "*Failures:* " + ", ".join(failures)
+    if len(successes) + len(failures) == 0:
+        summary += (
+            "\n"
+            + "No student records processed. To process a student record, create a `flush_pensieve` column on the Roster sheet, and set the value to TRUE for each record you would like to flush to Pensieve."
+        )
+
+    slack.send_message(summary)

--- a/src/pensieve.py
+++ b/src/pensieve.py
@@ -1,0 +1,60 @@
+from typing import List
+
+import requests
+
+from src.environment import Environment
+from src.errors import KnownError
+from src.utils import truncate
+
+
+class Pensieve:
+    """
+    Pensieve client to apply extensions for a student on an assignment.
+    """
+
+    def __init__(self) -> None:
+        email = Environment.get_pensieve_email()
+        token = Environment.get_pensieve_api_token()
+
+        if not email:
+            raise KnownError("PENSIEVE_EMAIL must be set to use Pensieve.")
+        if not token:
+            raise KnownError("PENSIEVE_API_TOKEN must be set to use Pensieve.")
+
+        self.base_url = "https://api.pensieve.co"
+        self.email = email
+        self.token = token
+
+    @staticmethod
+    def is_enabled():
+        return Environment.get_extend_pensieve_assignments() in ["Yes", "TRUE"]
+
+    def apply_extension(self, assignment_name: str, assignment_urls: List[str], email: str, num_days: int) -> List[str]:
+        warnings = []
+        course_name = Environment.get_course_name()
+
+        for assignment_url in assignment_urls:
+            prefix = '[{}] [{}{}] [{}] [{}] '.format(
+                email, course_name + ' ', assignment_name, assignment_url, num_days)
+            try:
+                resp = requests.post(
+                    f"{self.base_url}/api/b2s/v1/external-client/grant-extension",
+                    headers={"Authorization": f"Bearer {self.token}", "Content-Type": "application/json"},
+                    json={
+                        "assignment_url": assignment_url,
+                        "student_email": email,
+                        "num_days": num_days,
+                    },
+                    timeout=30,
+                )
+                if resp.status_code != 200:
+                    raise Exception(f"HTTP {resp.status_code}: {truncate(resp.text)}")
+                data = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
+                if not data or not data.get("success", False):
+                    raise Exception(truncate(data))
+            except Exception as err:
+                warnings.append(
+                    prefix
+                    + f"failed to extend assignment in Pensieve: internal Pensieve error occurred ({truncate(err)})"
+                )
+        return warnings

--- a/src/policy.py
+++ b/src/policy.py
@@ -4,10 +4,12 @@ from src.assignments import AssignmentList
 from src.email import Email
 from src.environment import Environment
 from src.gradescope import Gradescope
+from src.pensieve import Pensieve
 from src.record import StudentRecord
 from src.sheets import Sheet
 from src.slack import SlackManager
 from src.submission import FormSubmission
+
 
 class Policy:
     def __init__(
@@ -287,5 +289,11 @@ class Policy:
         if Gradescope.is_enabled():
             client = Gradescope()
             warnings = target.apply_extensions(assignments=self.assignments, gradescope=client)
+            for warning in warnings:
+                self.slack.add_warning(warning)
+
+        if Pensieve.is_enabled():
+            pensieve_client = Pensieve()
+            warnings = target.apply_extensions_pensieve(assignments=self.assignments, pensieve=pensieve_client)
             for warning in warnings:
                 self.slack.add_warning(warning)

--- a/src/record.py
+++ b/src/record.py
@@ -10,10 +10,9 @@ from src.assignments import AssignmentList
 from src.environment import Environment
 from src.errors import StudentRecordError
 from src.gradescope import Gradescope
+from src.pensieve import Pensieve
 from src.sheets import Sheet
-from src.utils import cast_bool 
-
-import json
+from src.utils import cast_bool
 
 APPROVAL_STATUS_REQUESTED_MEETING = "Requested Meeting"
 APPROVAL_STATUS_PENDING = "Pending"
@@ -101,7 +100,16 @@ class StudentRecord:
         if "flush_gradescope" in self.sheet.get_headers():
             self.queue_write_back(col_key="flush_gradescope", col_value=False)
 
-    def count_requests(self, assignments=AssignmentList):
+    def should_flush_pensieve(self):
+        if "flush_pensieve" in self.sheet.get_headers():
+            return cast_bool(self.table_record["flush_pensieve"])
+        return False
+
+    def set_flush_pensieve_status_success(self):
+        if "flush_pensieve" in self.sheet.get_headers():
+            self.queue_write_back(col_key="flush_pensieve", col_value=False)
+
+    def count_requests(self, assignments: AssignmentList) -> int:
         count = 0
         for assignment_id in assignments.get_all_ids():
             if self.get_request(assignment_id=assignment_id) is not None:
@@ -141,7 +149,7 @@ class StudentRecord:
         if self.table_index == -1:
             values = [self.write_queue.get(header) for header in headers]
             # minus 1 to account for header row
-            self.table_index = self.sheet.num_entries - 1 
+            self.table_index = self.sheet.num_entries - 1
             self.sheet.append_row(values=values, value_input_option="USER_ENTERED")
 
             # Update local table_record object for email.
@@ -164,7 +172,7 @@ class StudentRecord:
         warnings = []
         for assignment in assignments:
             num_days = self.get_request(assignment_id=assignment.get_id())
-            course_name = Environment.safe_get("COURSE_NAME", "")
+            course_name = Environment.get_course_name()
 
             if num_days:
 
@@ -190,6 +198,40 @@ class StudentRecord:
                         num_days=num_days,
                     )
                     warnings.extend(warnings)
+
+        return warnings
+
+    def apply_extensions_pensieve(self, assignments: AssignmentList, pensieve: Pensieve) -> List[str]:
+
+        warnings = []
+        for assignment in assignments:
+            num_days = self.get_request(assignment_id=assignment.get_id())
+            course_name = Environment.get_course_name()
+
+            if num_days:
+
+                if len(assignment.get_pensieve_assignment_urls()) == 0:
+                    print(
+                        "[{}{}] could not extend assignment deadline for {} (assignment URL's not set).".format(
+                            course_name + " ", assignment.get_name(), self.get_email()))
+                    continue
+
+                elif not assignment.get_due_date():
+                    warnings.append(
+                        "[{} {}] could not extend assignment deadline for {} (deadline not set).".format(
+                            course_name + " ", assignment.get_name(), self.get_email()))
+                    continue
+
+                else:
+                    print("Extending assignments (Pensieve): [{}{}] {}".format(
+                        course_name + " ", assignment.get_name(), str(assignment.get_pensieve_assignment_urls())))
+                    pensieve_warnings = pensieve.apply_extension(
+                        assignment_name=assignment.get_name(),
+                        assignment_urls=assignment.get_pensieve_assignment_urls(),
+                        email=self.get_email(),
+                        num_days=num_days,
+                    )
+                    warnings.extend(pensieve_warnings)
 
         return warnings
 


### PR DESCRIPTION
# Background

CS61A, Data100, Data8 is using Pensieve as a grading platform in 2025 Fall and this PR implements Pensieve support.

I've also developed an accompanying API in the Pensieve Platform that closely matches current api.

However since I do not have access to spreadsheets, form, flextension, slack, etc I was not able to test this out. 

# Changes

This assumes that the spreadsheet is modified to have following enviornment variables:
- EXTEND_PENSIEVE_ASSIGNMENTS
- PENSIEVE_EMAIL
- PENSIEVE_API_TOKEN

It also assumes that there's a column called 'flush_pensieve' along with 'flush_gradescope'. I did not quiet get how flush_gradescope column gets set and used, so I just tried to duplicate the existing logic for gradscope. Unsure if this is the right approach.

# API

The added api closely matches the usecase of this repo and it takes:
- assignment_url: any url which contains class_id and assignment_id (both student/teacher links are fine)
- student email
- num_days

and as per #3 it will only override if it is more lenient than existing due dates. It will also extend hard due dates if they exist.

```sh
❯ curl -X POST 'https://api.pensieve.co/api/b2s/v1/external-client/grant-extension' \
  -H 'Authorization: Bearer {api_token}' \
  -H 'Content-Type: application/json' \
  -d '{
    "assignment_url": "https://www.pensieve.co/teacher/classes/pensievedemoschool_demo10_su25/my-assignments/759297e8-cccb-4b57-8cc7-9fb1aa06a3d5/extensions",
    "student_email": "david.kim@example.com",
    "num_days": 5
  }'
{"success":true,"message":"Successfully updated extension to 5 days for student david.kim@example.com"}
```

Currently APIs are invite-only and I've added silascs@berkeley.edu to this course:

https://www.pensieve.co/teacher/classes/pensievedemoschool_extensionsapisandbox_fa25/my-assignments

log in with the account and click your name in the left navbar to generate an api key.

<img width="2006" height="1904" alt="CleanShot 2025-08-28 at 16 31 32@2x" src="https://github.com/user-attachments/assets/058d9d05-5161-4d75-8818-dfbd8ed755f5" />


After the api call you can verify the extension api went through in the assignment extension tab.

<img width="2484" height="1498" alt="CleanShot 2025-08-28 at 17 00 13@2x" src="https://github.com/user-attachments/assets/463366fa-de81-444f-82c4-c355f659bc06" />



# Asks

Please advise on how to test and distribute to the CS61A, Data100, Data8 classes.

Note: I'd like to also write the documentation for it after it is confirmed that it works.